### PR TITLE
FIX: When SIGHUP is received write to trigger_regen_w pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /.yardoc
 /coverage
 /.bundle
+/cfg.txt
 
 .rubocop-https---raw-githubusercontent-com-discourse-discourse-master--rubocop-yml

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -196,7 +196,7 @@ class ConfigSkeleton < ServiceSkeleton
 
     hook_signal(:HUP) do
       logger.info("SIGHUP") { "received SIGHUP, triggering config regeneration" }
-      regenerate_config(force_reload: true)
+      @trigger_regen_w << "."
     end
 
     initialize_config_skeleton_metrics

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -201,6 +201,7 @@ class ConfigSkeleton < ServiceSkeleton
 
     initialize_config_skeleton_metrics
     @trigger_regen_r, @trigger_regen_w = IO.pipe
+    @terminate_r, @terminate_w = IO.pipe
   end
 
   # Expose the write pipe which can be written to to trigger a config
@@ -229,8 +230,6 @@ class ConfigSkeleton < ServiceSkeleton
     watch(*self.class.watches)
 
     logger.debug(logloc) { "notifier fd is #{notifier.to_io.inspect}" }
-
-    @terminate_r, @terminate_w = IO.pipe
 
     loop do
       if ios = IO.select(

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -95,14 +95,10 @@ RSpec.describe ConfigSkeleton do
     expect(config_before_hup).not_to eq(config_after_hup)
   end
 
-  def wait_until
-    Timeout::timeout(2) do
-      loop do
-        condition = yield
-        if condition
-          break
-        end
-      end
+  def wait_until(timeout = 2, &blk)
+    till = Time.now + (timeout.to_f / 1000)
+    while Time.now < till && !blk.call
+      sleep 0.001
     end
   end
 end

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -45,28 +45,39 @@ RSpec.describe ConfigSkeleton do
   end
 
   it "respects the shutdown and breaks the run loop" do
-    expect(subject).to receive(:shutdown).and_call_original
-    Thread.new { sleep 0.5; subject.shutdown }
-    subject.run
-    expect(true).to eq(true)
+    thread = Thread.new { subject.run }
+    wait_until { File.read(cfg_file_path) != "" }
+    subject.shutdown
+    wait_until { !thread.alive? }
+    expect(thread.alive?).to eq(false)
   end
 
   it "watches for file changes and regenerates config on change" do
-    expect(subject).to receive(:regenerate_config).once.and_call_original
-    expect(subject).to receive(:regenerate_config).with(force_reload: true).once.and_call_original
-    Thread.new { sleep 0.5; File.write(tmp_watch_file, "some data") }
-    Thread.new { sleep 1.5; subject.shutdown }
-    subject.run
+    Thread.new { subject.run }
+    wait_until { File.read(cfg_file_path) != "" }
+    config_before_file_change = File.read(cfg_file_path)
+    File.write(tmp_watch_file, "some data");
+    config_after_file_change = nil
+    wait_until { config_after_file_change = File.read(cfg_file_path) != config_before_file_change }
+    expect(config_before_file_change).not_to eq(config_after_file_change)
   end
 
   it "watches for a regen trigger write and regenerate the config" do
-    expect(subject).to receive(:regenerate_config).with(force_reload: true).twice.and_call_original
-    expect(subject).to receive(:regenerate_config).once.and_call_original
     notif = subject.regen_notifier
-    Thread.new { sleep 0.5; notif.trigger_regen }
-    Thread.new { sleep 1.5; notif.trigger_regen }
-    Thread.new { sleep 2.5; subject.shutdown }
-    subject.run
+    Thread.new { subject.run }
+
+    wait_until { File.read(cfg_file_path) != "" }
+    config_before_trigger = File.read(cfg_file_path)
+    notif.trigger_regen
+    config_after_trigger = nil
+    wait_until { config_after_trigger = File.read(cfg_file_path) != config_before_trigger }
+    expect(config_before_trigger).not_to eq(config_after_trigger)
+
+    config_before_trigger = File.read(cfg_file_path)
+    notif.trigger_regen
+    config_after_trigger = nil
+    wait_until { config_after_trigger = File.read(cfg_file_path) != config_before_trigger }
+    expect(config_before_trigger).not_to eq(config_after_trigger)
   end
 
   it "listens for a SIGHUP signal and regenerates the config" do
@@ -74,14 +85,24 @@ RSpec.describe ConfigSkeleton do
       # needs start instead of run otherwise signals are not trapped
       subject.start
     end
-    sleep 1
+    wait_until { File.read(cfg_file_path) != "" }
 
     config_before_hup = File.read(cfg_file_path)
     Process.kill('HUP', pid)
-
-    sleep 1
     Process.kill('TERM', pid)
-    config_after_hup = File.read(cfg_file_path)
+    config_after_hup = nil
+    wait_until { config_after_hup = File.read(cfg_file_path) != config_before_hup }
     expect(config_before_hup).not_to eq(config_after_hup)
+  end
+
+  def wait_until
+    Timeout::timeout(2) do
+      loop do
+        condition = yield
+        if condition
+          break
+        end
+      end
+    end
   end
 end

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -3,13 +3,14 @@
 require 'config_skeleton'
 
 RSpec.describe ConfigSkeleton do
+  let(:cfg_file_path) { "#{Dir.pwd}/cfg.txt" }
   let(:env) do
     {
-      "MY_CONFIG_FILE" => tmp_config_file.path,
-      "MY_CONFIG_WATCH_FILE" => tmp_watch_file.path
+      "MY_CONFIG_FILE" => cfg_file_path,
+      "MY_CONFIG_WATCH_FILE" => tmp_watch_file.path,
+      "MY_CONFIG_LOG_LEVEL" => "info"
     }
   end
-  let(:tmp_config_file) { Tempfile.new }
   let(:tmp_watch_file) { Tempfile.new }
 
   class MyConfig < ConfigSkeleton
@@ -26,7 +27,7 @@ RSpec.describe ConfigSkeleton do
     end
 
     def config_data
-      "nothing to see here\n"
+      "important config data #{SecureRandom.hex(6)}\n"
     end
 
     def reload_server
@@ -35,7 +36,14 @@ RSpec.describe ConfigSkeleton do
   end
 
   let(:subject) { MyConfig.new(env) }
-  
+
+  before do
+    if File.file?(cfg_file_path)
+      FileUtils.rm(cfg_file_path)
+    end
+    FileUtils.touch(cfg_file_path)
+  end
+
   it "respects the shutdown and breaks the run loop" do
     expect(subject).to receive(:shutdown).and_call_original
     Thread.new { sleep 0.5; subject.shutdown }
@@ -59,5 +67,21 @@ RSpec.describe ConfigSkeleton do
     Thread.new { sleep 1.5; notif.trigger_regen }
     Thread.new { sleep 2.5; subject.shutdown }
     subject.run
+  end
+
+  it "listens for a SIGHUP signal and regenerates the config" do
+    pid = fork do
+      # needs start instead of run otherwise signals are not trapped
+      subject.start
+    end
+    sleep 1
+
+    config_before_hup = File.read(cfg_file_path)
+    Process.kill('HUP', pid)
+
+    sleep 1
+    Process.kill('TERM', pid)
+    config_after_hup = File.read(cfg_file_path)
+    expect(config_before_hup).not_to eq(config_after_hup)
   end
 end

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ConfigSkeleton do
     expect(config_before_hup).not_to eq(config_after_hup)
   end
 
-  def wait_until(timeout = 2, &blk)
+  def wait_until(timeout = 2000, &blk)
     till = Time.now + (timeout.to_f / 1000)
     while Time.now < till && !blk.call
       sleep 0.001

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'pry'
+require 'pry-byebug'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
This previous commit https://github.com/discourse/config_skeleton/commit/71d38c810db9dbd41c18a94b9d2a51ed185c5a64 added a `@trigger_regen_w` pipe that can be written to to break IO.select and run config regeneration. This PR changes the SIGHUP handler to use the same method instead of calling `regenerate_config` directly to avoid race conditions.