### PR TITLE
Update to Service Skeleton 1.0

### DIFF
--- a/config_skeleton.gemspec
+++ b/config_skeleton.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'diffy', '~> 3.0'
-  s.add_runtime_dependency 'frankenstein', '~> 1.0'
   s.add_runtime_dependency 'rb-inotify', '~> 0.9'
   s.add_runtime_dependency 'service_skeleton', "~> 1.0"
 

--- a/config_skeleton.gemspec
+++ b/config_skeleton.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'diffy', '~> 3.0'
+  s.add_runtime_dependency 'frankenstein', '~> 1.0'
   s.add_runtime_dependency 'rb-inotify', '~> 0.9'
   s.add_runtime_dependency 'service_skeleton', "~> 1.0"
 

--- a/config_skeleton.gemspec
+++ b/config_skeleton.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = "config_skeleton"
 
-  s.version = "0.4.1"
+  s.version = "1.0.0"
 
   s.platform = Gem::Platform::RUBY
 
@@ -16,9 +16,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'diffy', '~> 3.0'
-  s.add_runtime_dependency 'frankenstein', '~> 1.0'
   s.add_runtime_dependency 'rb-inotify', '~> 0.9'
-  s.add_runtime_dependency 'service_skeleton', '> 0.a'
+  s.add_runtime_dependency 'service_skeleton', "~> 1.0"
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'github-release'

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -35,14 +35,13 @@ end
 #
 # 1. Setup any file watchers you want with .watch and #watch.
 #
-# 1. Instantiate your new class, passing in an environment hash, and then call
-#    #start.  Something like this should do the trick:
+# 1. Use the ServiceSkeleton Runner to start the service. Something like this should do the trick:
 #
 #        class MyConfigGenerator < ConfigSkeleton
 #          # Implement all the necessary methods
 #        end
 #
-#        MyConfigGenerator.new(ENV).start if __FILE__ == $0
+#        ServiceSkeleton::Runner.new(FilebeatConfig, ENV).run if __FILE__ == $0
 #
 # 1. Sit back and relax.
 #

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -7,7 +7,7 @@ require 'tempfile'
 require 'digest/md5'
 
 begin
-  require 'rb-inotify' unless ENV["DISABLE_INOTIFY"] == "1"
+  require 'rb-inotify' unless ENV["DISABLE_INOTIFY"]
 rescue FFI::NotFoundError => e
   STDERR.puts "ERROR: Unable to initialize rb-inotify. To disable, set DISABLE_INOTIFY=1"
   raise

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -2,10 +2,16 @@ require 'diffy'
 require 'fileutils'
 require 'frankenstein'
 require 'logger'
-require 'rb-inotify'
 require 'service_skeleton'
 require 'tempfile'
 require 'digest/md5'
+
+begin
+  require 'rb-inotify' unless ENV["DISABLE_INOTIFY"] == "1"
+rescue FFI::NotFoundError => e
+  STDERR.puts "ERROR: Unable to initialize rb-inotify. To disable, set DISABLE_INOTIFY=1"
+  raise
+end
 
 # Framework for creating config generation systems.
 #
@@ -136,7 +142,8 @@ require 'digest/md5'
 # method, passing one or more strings containing the full path to files or
 # directories to watch.
 #
-class ConfigSkeleton < ServiceSkeleton
+class ConfigSkeleton
+  include ServiceSkeleton
   # All ConfigSkeleton-related errors will be subclasses of this.
   class Error < StandardError; end
 
@@ -152,6 +159,19 @@ class ConfigSkeleton < ServiceSkeleton
 
     def trigger_regen
       @io_write << "."
+    end
+  end
+
+  def self.inherited(klass)
+    klass.gauge :"#{klass.service_name}_last_generation_timestamp", docstring: "When the last config generation run was made"
+    klass.gauge :"#{klass.service_name}_last_change_timestamp", docstring: "When the config file was last written to"
+    klass.counter :"#{klass.service_name}_reload_total", docstring: "How many times we've asked the server to reload", labels: [:status]
+    klass.counter :"#{klass.service_name}_signals_total", docstring: "How many signals have been received (and handled)"
+    klass.gauge :"#{klass.service_name}_config_ok", docstring: "Whether the last config change was accepted by the server"
+
+    klass.hook_signal("HUP") do
+      logger.info("SIGHUP") { "received SIGHUP, triggering config regeneration" }
+      @trigger_regen_w << "."
     end
   end
 
@@ -186,20 +206,8 @@ class ConfigSkeleton < ServiceSkeleton
     @watches || []
   end
 
-  # Create a new config generator.
-  #
-  # @param env [Hash<String, String>] the environment in which this config
-  #   generator runs.  Typically you'll just pass `ENV` in here, but you can
-  #   pass in any hash you like, for testing purposes.
-  #
-  def initialize(env)
+  def initialize(*_)
     super
-
-    hook_signal(:HUP) do
-      logger.info("SIGHUP") { "received SIGHUP, triggering config regeneration" }
-      @trigger_regen_w << "."
-    end
-
     initialize_config_skeleton_metrics
     @trigger_regen_r, @trigger_regen_w = IO.pipe
     @terminate_r, @terminate_w = IO.pipe
@@ -294,6 +302,7 @@ class ConfigSkeleton < ServiceSkeleton
   # @see .watch for watching files and directories whose path never changes.
   #
   def watch(*files)
+    return if ENV["DISABLE_INOTIFY"]
     files.each do |f|
       if File.directory?(f)
         notifier.watch(f, :recursive, :create, :modify, :delete, :move) { |ev| logger.info("#{logloc} watcher") { "detected #{ev.flags.join(", ")} on #{ev.watcher.path}/#{ev.name}; regenerating config" } }
@@ -305,22 +314,11 @@ class ConfigSkeleton < ServiceSkeleton
 
   private
 
-  # Register metrics in the ServiceSkeleton metrics registry
-  #
-  # @return [void]
-  #
   def initialize_config_skeleton_metrics
-    @config_generation = Frankenstein::Request.new("#{service_name}_generation", outgoing: false, description: "config generation", registry: metrics)
-
-    metrics.gauge(:"#{service_name}_last_generation_timestamp", "When the last config generation run was made")
-    metrics.gauge(:"#{service_name}_last_change_timestamp", "When the config file was last written to")
-    metrics.counter(:"#{service_name}_reload_total", "How many times we've asked the server to reload")
-    metrics.counter(:"#{service_name}_signals_total", "How many signals have been received (and handled)")
-    metrics.gauge(:"#{service_name}_config_ok", "Whether the last config change was accepted by the server")
-
-    metrics.last_generation_timestamp.set({}, 0)
-    metrics.last_change_timestamp.set({}, 0)
-    metrics.config_ok.set({}, 0)
+    @config_generation = Frankenstein::Request.new("#{self.class.service_name}_generation", outgoing: false, description: "config generation", registry: metrics)
+    metrics.last_generation_timestamp.set(0)
+    metrics.last_change_timestamp.set(0)
+    metrics.config_ok.set(0)
   end
 
   # Write out a config file if one doesn't exist, or do an initial regen run
@@ -335,7 +333,7 @@ class ConfigSkeleton < ServiceSkeleton
     else
       logger.info(logloc) { "No existing config file #{config_file} found; writing one" }
       File.write(config_file, instrumented_config_data)
-      metrics.last_change_timestamp.set({}, Time.now.to_f)
+      metrics.last_change_timestamp.set(Time.now.to_f)
     end
   end
 
@@ -423,7 +421,7 @@ class ConfigSkeleton < ServiceSkeleton
   #
   def instrumented_config_data
     begin
-      @config_generation.measure { config_data.tap { metrics.last_generation_timestamp.set({}, Time.now.to_f) } }
+      @config_generation.measure { config_data.tap { metrics.last_generation_timestamp.set(Time.now.to_f) } }
     rescue => ex
       log_exception(ex, logloc) { "Call to config_data raised exception" }
       nil
@@ -453,6 +451,9 @@ class ConfigSkeleton < ServiceSkeleton
   #
   def notifier
     @notifier ||= INotify::Notifier.new
+  rescue NameError
+    raise if !ENV["DISABLE_INOTIFY"]
+    @notifier ||= Struct.new(:to_io).new(IO.pipe[1]) # Stub for macOS development
   end
 
   # Do the hard yards of actually regenerating the config and performing the reload.
@@ -474,7 +475,7 @@ class ConfigSkeleton < ServiceSkeleton
     )
 
     logger.debug(logloc) { "force? #{force_reload.inspect}" }
-    tmpfile = Tempfile.new(service_name, File.dirname(config_file))
+    tmpfile = Tempfile.new(self.class.service_name, File.dirname(config_file))
     logger.debug(logloc) { "Tempfile is #{tmpfile.path}" }
     unless (new_config = instrumented_config_data).nil?
       File.write(tmpfile.path, new_config)
@@ -512,7 +513,7 @@ class ConfigSkeleton < ServiceSkeleton
       new_config_hash: new_config_hash
     )
   ensure
-    metrics.last_change_timestamp.set({}, File.stat(config_file).mtime.to_f)
+    metrics.last_change_timestamp.set(File.stat(config_file).mtime.to_f)
     tmpfile.close rescue nil
     tmpfile.unlink rescue nil
   end
@@ -562,7 +563,7 @@ class ConfigSkeleton < ServiceSkeleton
         logger.debug(logloc) { "Restored previous config file" }
         File.rename(old_copy, config_file)
       end
-      metrics.reload_total.increment(status: "failure")
+      metrics.reload_total.increment(labels: { status: "failure" })
 
       return
     end
@@ -570,21 +571,21 @@ class ConfigSkeleton < ServiceSkeleton
     logger.debug(logloc) { "Server reloaded successfully" }
 
     if config_ok?
-      metrics.config_ok.set({}, 1)
+      metrics.config_ok.set(1)
       logger.debug(logloc) { "Configuration successfully updated." }
-      metrics.reload_total.increment(status: "success")
-      metrics.last_change_timestamp.set({}, Time.now.to_f)
+      metrics.reload_total.increment(labels: { status: "success" })
+      metrics.last_change_timestamp.set(Time.now.to_f)
     else
-      metrics.config_ok.set({}, 0)
+      metrics.config_ok.set(0)
       if config_was_ok
         logger.warn(logloc) { "New config file failed config_ok? test; rolling back to previous known-good config" }
         File.rename(old_copy, config_file)
         reload_server
-        metrics.reload_total.increment(status: "bad-config")
+        metrics.reload_total.increment(labels: { status: "bad-config" })
       else
         logger.warn(logloc) { "New config file failed config_ok? test; leaving new config in place because old config is broken too" }
-        metrics.reload_total.increment(status: "everything-is-awful")
-        metrics.last_change_timestamp.set({}, Time.now.to_f)
+        metrics.reload_total.increment(labels: { status: "everything-is-awful" })
+        metrics.last_change_timestamp.set(Time.now.to_f)
       end
     end
   ensure

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ConfigSkeleton do
     {
       "MY_CONFIG_FILE" => cfg_file_path,
       "MY_CONFIG_WATCH_FILE" => tmp_watch_file.path,
-      "MY_CONFIG_LOG_LEVEL" => "info"
+      "MY_CONFIG_LOG_LEVEL" => "ERROR"
     }
   end
   let(:tmp_watch_file) { Tempfile.new }
@@ -33,9 +33,26 @@ RSpec.describe ConfigSkeleton do
     def reload_server
       true
     end
+
+    attr_accessor :before_regenerate_data, :after_regenerate_data
+
+    def before_regenerate_config(**kwargs)
+      @before_regenerate_data ||= []
+      @before_regenerate_data << kwargs
+    end
+
+    def after_regenerate_config(**kwargs)
+      @after_regenerate_data ||= []
+      @after_regenerate_data << kwargs
+    end
   end
 
-  let(:subject) { MyConfig.new(env) }
+  let(:runner) { ServiceSkeleton::Runner.new(MyConfig, env) }
+  let(:ultravisor) { runner.instance_variable_get(:@ultravisor) }
+  
+  def instance
+    ultravisor[:my_config].unsafe_instance
+  end
 
   before do
     if File.file?(cfg_file_path)
@@ -45,26 +62,27 @@ RSpec.describe ConfigSkeleton do
   end
 
   it "respects the shutdown and breaks the run loop" do
-    thread = Thread.new { subject.run }
+    thread = Thread.new { runner.run }
     wait_until { File.read(cfg_file_path) != "" }
-    subject.shutdown
-    wait_until { !thread.alive? }
-    expect(thread.alive?).to eq(false)
+    ultravisor.shutdown
+    thread.join(2)
   end
 
   it "watches for file changes and regenerates config on change" do
-    Thread.new { subject.run }
+    thread = Thread.new { runner.run }
     wait_until { File.read(cfg_file_path) != "" }
     config_before_file_change = File.read(cfg_file_path)
     File.write(tmp_watch_file, "some data");
     config_after_file_change = nil
     wait_until { config_after_file_change = File.read(cfg_file_path) != config_before_file_change }
     expect(config_before_file_change).not_to eq(config_after_file_change)
+    ultravisor.shutdown
+    thread.join(2)
   end
 
   it "watches for a regen trigger write and regenerate the config" do
-    notif = subject.regen_notifier
-    Thread.new { subject.run }
+    thread = Thread.new { runner.run }
+    notif = instance.regen_notifier
 
     wait_until { File.read(cfg_file_path) != "" }
     config_before_trigger = File.read(cfg_file_path)
@@ -78,35 +96,48 @@ RSpec.describe ConfigSkeleton do
     config_after_trigger = nil
     wait_until { config_after_trigger = File.read(cfg_file_path) != config_before_trigger }
     expect(config_before_trigger).not_to eq(config_after_trigger)
+
+    ultravisor.shutdown
+    thread.join(2)
   end
 
   it "listens for a SIGHUP signal and regenerates the config" do
     pid = fork do
-      # needs start instead of run otherwise signals are not trapped
-      subject.start
+      runner.run
     end
     wait_until { File.read(cfg_file_path) != "" }
 
     config_before_hup = File.read(cfg_file_path)
     Process.kill('HUP', pid)
-    Process.kill('TERM', pid)
     config_after_hup = nil
-    wait_until { config_after_hup = File.read(cfg_file_path) != config_before_hup }
+    wait_until { (config_after_hup = File.read(cfg_file_path)) != config_before_hup }
     expect(config_before_hup).not_to eq(config_after_hup)
+
+    Process.kill('TERM', pid)
+    Process.wait(pid)
   end
 
   it "calls before_regenerate_config with the appropriate arguments" do
-    expect(subject).to receive(:before_regenerate_config).with(force_reload: false, existing_config_hash: kind_of(String), existing_config_data: kind_of(String)).at_least(:once)
-    expect(subject).to receive(:before_regenerate_config).with(force_reload: true, existing_config_hash: kind_of(String), existing_config_data: kind_of(String)).at_least(:once)
-    force_regen_with_notifier
-    sleep 1
-  end
+    thread = Thread.new { runner.run }
 
-  it "calls after_regenerate_config with the appropriate arguments" do
-    expect(subject).to receive(:after_regenerate_config).with(force_reload: false, config_was_different: true, config_was_cycled: true, new_config_hash: kind_of(String)).at_least(:once)
-    expect(subject).to receive(:after_regenerate_config).with(force_reload: true, config_was_different: true, config_was_cycled: true, new_config_hash: kind_of(String)).at_least(:once)
-    force_regen_with_notifier
-    sleep 1
+    wait_until { !instance.nil? }
+    instance.regen_notifier.trigger_regen
+
+    wait_until { instance.before_regenerate_data&.size == 2 }
+    wait_until { instance.after_regenerate_data&.size == 2 }
+
+    expect(instance.before_regenerate_data).to include(
+      { force_reload: false, existing_config_hash: kind_of(String), existing_config_data: kind_of(String)},
+      { force_reload: true, existing_config_hash: kind_of(String), existing_config_data: kind_of(String)}
+    )
+
+    expect(instance.after_regenerate_data).to include(
+      { force_reload: false, config_was_different: true, config_was_cycled: true, new_config_hash: kind_of(String) },
+      { force_reload: true, config_was_different: true, config_was_cycled: true, new_config_hash: kind_of(String) }
+    )
+
+    ultravisor.shutdown
+    thread.join(2)
   end
 
   def force_regen_with_notifier
@@ -120,10 +151,11 @@ RSpec.describe ConfigSkeleton do
     wait_until { config_after_trigger = File.read(cfg_file_path) != config_before_trigger }
   end
 
-  def wait_until(timeout = 2000, &blk)
-    till = Time.now + (timeout.to_f / 1000)
-    while Time.now < till && !blk.call
+  def wait_until(timeout = 2, &blk)
+    till = Time.now + timeout
+    while !blk.call
       sleep 0.001
+      raise "Condition not met after 2 seconds" if Time.now > till
     end
   end
 end


### PR DESCRIPTION
This is a major refactoring, and some interfaces have changed. It will be a breaking change for all consumers, hence the major version bump.

Major changes include:
  - The way you start the service has changed. You must now use ServiceSkeleton::Runner to start it.
  - The Frankenstein metrics interface has changed slightly. Labels must be specified at initialization, and provided via a keyword argument when observing/incrementing

Other changes include:
- A DISABLE_INOTIFY switch has also been added, to aid people developing on macOS, where inotify is not supported.