### PR TITLE
FEATURE: Add cooldown_duration to reduce regen frequency

### DIFF
--- a/config_skeleton.gemspec
+++ b/config_skeleton.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name = "config_skeleton"
 
-  s.version = "2.0.0"
+  s.version = "2.1.0"
 
   s.platform = Gem::Platform::RUBY
 

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -242,11 +242,16 @@ class ConfigSkeleton
     logger.debug(logloc) { "notifier fd is #{notifier.to_io.inspect}" }
 
     loop do
-      if ios = IO.select(
-          [notifier.to_io, @terminate_r, @trigger_regen_r],
-          [], [],
-          sleep_duration.tap { |d| logger.debug(logloc) { "Sleeping for #{d} seconds" } }
-      )
+      if cooldown_duration > 0
+        logger.debug(logloc) { "Sleeping for #{cooldown_duration} seconds (cooldown)" }
+        IO.select([@terminate_r], [], [], cooldown_duration)
+      end
+
+      timeout = sleep_duration - cooldown_duration
+      logger.debug(logloc) { "Sleeping for #{timeout} seconds unless interrupted" }
+      ios = IO.select([notifier.to_io, @terminate_r, @trigger_regen_r], [], [], timeout)
+
+      if ios
         if ios.first.include?(notifier.to_io)
           logger.debug(logloc) { "inotify triggered" }
           notifier.process
@@ -444,6 +449,21 @@ class ConfigSkeleton
   #
   def sleep_duration
     60
+  end
+
+  # How long to ignore signals/notifications after a config regeneration
+  #
+  # Hammering a downstream service with reload requests is often a bad idea.
+  # This method exists to allow subclasses to define a 'cooldown' duration.
+  # After each config regeneration, the config generator will sleep for this
+  # duration, regardless of any CONT signals or inotify events. Those events
+  # will be queued up, and processed at the end of the cooldown.
+  #
+  # @return [Integer] the number of seconds to 'cooldown' for.  This *must* be
+  #   greater than zero, and less than sleep_duration
+  #
+  def cooldown_duration
+    5
   end
 
   # The instance of INotify::Notifier that is holding our file watches.

--- a/lib/config_skeleton.rb
+++ b/lib/config_skeleton.rb
@@ -212,6 +212,10 @@ class ConfigSkeleton
     initialize_config_skeleton_metrics
     @trigger_regen_r, @trigger_regen_w = IO.pipe
     @terminate_r, @terminate_w = IO.pipe
+
+    raise "cooldown_duration invalid" if cooldown_duration < 0
+    raise "sleep_duration invalid" if sleep_duration < 0
+    raise "sleep_duration must not be less than cooldown_duration" if sleep_duration < cooldown_duration
   end
 
   # Expose the write pipe which can be written to to trigger a config
@@ -458,6 +462,10 @@ class ConfigSkeleton
   # After each config regeneration, the config generator will sleep for this
   # duration, regardless of any CONT signals or inotify events. Those events
   # will be queued up, and processed at the end of the cooldown.
+  #
+  # The cooldown_duration is counted as part of the sleep_duration. So for
+  # the default values of 60 and 5, the service will cooldown for 5s, then wait
+  # for 55s.
   #
   # @return [Integer] the number of seconds to 'cooldown' for.  This *must* be
   #   greater than zero, and less than sleep_duration

--- a/spec/config_skeleton_spec.rb
+++ b/spec/config_skeleton_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe ConfigSkeleton do
       true
     end
 
+    def cooldown_duration
+      0.01
+    end
+
     attr_accessor :before_regenerate_data, :after_regenerate_data
 
     def before_regenerate_config(**kwargs)


### PR DESCRIPTION
Hammering a downstream service with reload requests is often a bad idea.
This method exists to allow subclasses to define a 'cooldown' duration.
After each config regeneration, the config generator will sleep for this
duration, regardless of any CONT signals or inotify events. Those events
will be queued up, and processed at the end of the cooldown.

Defaults to 5 seconds, but can be altered by sub classes